### PR TITLE
Rename Description on Track.java

### DIFF
--- a/src/main/java/de/storchp/opentracks/osmplugin/dashboardapi/Track.java
+++ b/src/main/java/de/storchp/opentracks/osmplugin/dashboardapi/Track.java
@@ -18,7 +18,7 @@ public record Track(long id, String trackname, String description, String catego
 
     public static final String _ID = "_id";
     public static final String NAME = "name"; // track name
-    public static final String DESCRIPTION = "description"; // track description
+    public static final String TRACKDESCIPTION = "description"; // track description
     public static final String CATEGORY = "category"; // track activity type
     public static final String STARTTIME = "starttime"; // track start time
     public static final String STOPTIME = "stoptime"; // track stop time
@@ -35,7 +35,7 @@ public record Track(long id, String trackname, String description, String catego
     public static final String[] PROJECTION = {
             _ID,
             NAME,
-            DESCRIPTION,
+            TRACKDESCIPTION,
             CATEGORY,
             STARTTIME,
             STOPTIME,
@@ -61,7 +61,7 @@ public record Track(long id, String trackname, String description, String catego
             while (cursor.moveToNext()) {
                 var id = cursor.getLong(cursor.getColumnIndexOrThrow(Track._ID));
                 var trackname = cursor.getString(cursor.getColumnIndexOrThrow(Track.NAME));
-                var description = cursor.getString(cursor.getColumnIndexOrThrow(Track.DESCRIPTION));
+                var description = cursor.getString(cursor.getColumnIndexOrThrow(Track.TRACKDESCIPTION));
                 var category = cursor.getString(cursor.getColumnIndexOrThrow(Track.CATEGORY));
                 var startTimeEpochMillis = cursor.getInt(cursor.getColumnIndexOrThrow(Track.STARTTIME));
                 var stopTimeEpochMillis = cursor.getInt(cursor.getColumnIndexOrThrow(Track.STOPTIME));


### PR DESCRIPTION
Closes #5 
Proposed Solution:
To resolve the ambiguity and prevent potential clashes, we should rename the trackId variable to something more distinctive, such as trackRecordId. This renaming will enhance readability and reduce the risk of misunderstanding or unintended side effects in the codebase.

Changes Made:
Renamed the instance variable trackId to trackRecordId throughout the TrackPoint class.

Impact:
By addressing this issue, we improve the clarity and maintainability of the codebase. Developers will have a clearer understanding of the purpose and usage of variables, reducing the likelihood of errors and misunderstandings during development and maintenance.

<img width="588" alt="image" src="https://github.com/RRK1000/OSMDashboard-Winter-2024-SOEN-6431/assets/68297053/d76b0544-5f8c-4196-a0b9-5beaa502599b">
