### PR TITLE
integrate chair_name tag into DashboardAPI

### DIFF
--- a/src/main/java/de/storchp/opentracks/osmplugin/MapsActivity.java
+++ b/src/main/java/de/storchp/opentracks/osmplugin/MapsActivity.java
@@ -724,6 +724,12 @@ public class MapsActivity extends BaseActivity implements ItemizedLayer.OnItemGe
                         JSONArray nodes = element.getJSONArray("nodes"); // Getting the nodes array
                         JSONArray geometry = element.getJSONArray("geometry"); // coordinates
                         String name = tags.optString("name", "Unnamed");
+
+                        // integrate chair_lift tags into tracks
+                        ChairLift chairLift = ChairLift.getInstance(); // singleton class
+                        ChairLiftElements chairLiftElements = ChairLiftElements.parseJsonElement(element);
+                        chairLift.addTrailData(chairLiftElements); // adds chairLift element list in the chairLifts
+
                         // Now you can use these variables as needed
                         Log.i(TAG, "Type: " + type + ", ID: " + id + ", Name: " + name);
                     }

--- a/src/main/java/de/storchp/opentracks/osmplugin/MapsActivity.java
+++ b/src/main/java/de/storchp/opentracks/osmplugin/MapsActivity.java
@@ -91,6 +91,8 @@ import javax.microedition.khronos.egl.EGLContext;
 import javax.microedition.khronos.opengles.GL10;
 
 import de.storchp.opentracks.osmplugin.dashboardapi.APIConstants;
+import de.storchp.opentracks.osmplugin.dashboardapi.ChairLift;
+import de.storchp.opentracks.osmplugin.dashboardapi.ChairLiftElements;
 import de.storchp.opentracks.osmplugin.dashboardapi.SkiElements;
 import de.storchp.opentracks.osmplugin.dashboardapi.Track;
 import de.storchp.opentracks.osmplugin.dashboardapi.TrackPoint;
@@ -716,6 +718,10 @@ public class MapsActivity extends BaseActivity implements ItemizedLayer.OnItemGe
 
                     // extracting data
                     JSONArray elements = jsonResponse.getJSONArray("elements");
+
+                    // integrate chair_lift tags into tracks
+                    ChairLift chairLift = ChairLift.getInstance(); // singleton class
+                    chairLift.clearData();
                     for (int i = 0; i < elements.length(); i++) {
                         JSONObject element = elements.getJSONObject(i);
                         String type = element.getString("type");
@@ -725,10 +731,8 @@ public class MapsActivity extends BaseActivity implements ItemizedLayer.OnItemGe
                         JSONArray geometry = element.getJSONArray("geometry"); // coordinates
                         String name = tags.optString("name", "Unnamed");
 
-                        // integrate chair_lift tags into tracks
-                        ChairLift chairLift = ChairLift.getInstance(); // singleton class
                         ChairLiftElements chairLiftElements = ChairLiftElements.parseJsonElement(element);
-                        chairLift.addTrailData(chairLiftElements); // adds chairLift element list in the chairLifts
+                        chairLift.addChairLiftData(chairLiftElements); // adds chairLift element list in the chairLifts
 
                         // Now you can use these variables as needed
                         Log.i(TAG, "Type: " + type + ", ID: " + id + ", Name: " + name);

--- a/src/main/java/de/storchp/opentracks/osmplugin/dashboardapi/ChairLift.java
+++ b/src/main/java/de/storchp/opentracks/osmplugin/dashboardapi/ChairLift.java
@@ -3,25 +3,6 @@ package de.storchp.opentracks.osmplugin.dashboardapi;
 import java.util.ArrayList;
 import java.util.List;
 
-class Bounds {
-    public double minlat;
-    public double minlon;
-    public double maxlat;
-    public double maxlon;
-
-    // Constructor
-    public Bounds(double minlat, double minlon, double maxlat, double maxlon) {
-        this.minlat = minlat;
-        this.minlon = minlon;
-        this.maxlat = maxlat;
-        this.maxlon = maxlon;
-    }
-
-    public Bounds() {
-
-    }
-}
-
 public class ChairLift {
 
     private List<ChairLiftElements> chairLifts = new ArrayList<>();
@@ -43,32 +24,51 @@ public class ChairLift {
         return chairLifts;
     }
 
-    public void addChairLiftData(ChairLiftElements chair) {
-        chairLifts.add(chairLift);
+    public void addChairLiftData(ChairLiftElements chairLift) {
+        this.chairLifts.add(chairLift);
     }
 
     public void clearData() {
-        chairs.clear();
+        this.chairLifts.clear();
     }
 
 }
 
-class Geometry {
+class ChairLiftBounds {
+    public double minlat;
+    public double minlon;
+    public double maxlat;
+    public double maxlon;
+
+    // Constructor
+    public ChairLiftBounds(double minlat, double minlon, double maxlat, double maxlon) {
+        this.minlat = minlat;
+        this.minlon = minlon;
+        this.maxlat = maxlat;
+        this.maxlon = maxlon;
+    }
+
+    public ChairLiftBounds() {
+
+    }
+}
+
+class ChairLiftGeometry {
     public double lat;
     public double lon;
 
     // Constructor
-    public Geometry(double lat, double lon) {
+    public ChairLiftGeometry(double lat, double lon) {
         this.lat = lat;
         this.lon = lon;
     }
 
-    public Geometry() {
+    public ChairLiftGeometry() {
 
     }
 }
 
-class Tags {
+class ChairLiftTags {
     public String name;
     public String aerialway;
     public String aerialway_occupancy;
@@ -76,7 +76,7 @@ class Tags {
     public String aerialway_heating;
     public String aerialway_duration;
 
-    public Tags(String name, String aerialway, String aerialway_occupancy, String aerialway_bubble,
+    public ChairLiftTags(String name, String aerialway, String aerialway_occupancy, String aerialway_bubble,
             String aerialway_heating, String aerialway_duration) {
         this.name = name;
         this.aerialway = aerialway;
@@ -86,7 +86,7 @@ class Tags {
         this.aerialway_duration = aerialway_duration;
     }
 
-    public Tags() {
+    public ChairLiftTags() {
 
     }
 }

--- a/src/main/java/de/storchp/opentracks/osmplugin/dashboardapi/ChairLift.java
+++ b/src/main/java/de/storchp/opentracks/osmplugin/dashboardapi/ChairLift.java
@@ -1,0 +1,92 @@
+package de.storchp.opentracks.osmplugin.dashboardapi;
+
+import java.util.ArrayList;
+import java.util.List;
+
+class Bounds {
+    public double minlat;
+    public double minlon;
+    public double maxlat;
+    public double maxlon;
+
+    // Constructor
+    public Bounds(double minlat, double minlon, double maxlat, double maxlon) {
+        this.minlat = minlat;
+        this.minlon = minlon;
+        this.maxlat = maxlat;
+        this.maxlon = maxlon;
+    }
+
+    public Bounds() {
+
+    }
+}
+
+public class ChairLift {
+
+    private List<ChairLiftElements> chairLifts = new ArrayList<>();
+
+    private static ChairLift instance = null;
+
+    private ChairLift() {
+    }
+
+    // Static method to create instance of Singleton class
+    public static synchronized ChairLift getInstance() {
+        if (instance == null)
+            instance = new ChairLift();
+
+        return instance;
+    }
+
+    public List<ChairLiftElements> getChairLifts() {
+        return chairLifts;
+    }
+
+    public void addChairLiftData(ChairLiftElements chair) {
+        chairLifts.add(chairLift);
+    }
+
+    public void clearData() {
+        chairs.clear();
+    }
+
+}
+
+class Geometry {
+    public double lat;
+    public double lon;
+
+    // Constructor
+    public Geometry(double lat, double lon) {
+        this.lat = lat;
+        this.lon = lon;
+    }
+
+    public Geometry() {
+
+    }
+}
+
+class Tags {
+    public String name;
+    public String aerialway;
+    public String aerialway_occupancy;
+    public String aerialway_bubble;
+    public String aerialway_heating;
+    public String aerialway_duration;
+
+    public Tags(String name, String aerialway, String aerialway_occupancy, String aerialway_bubble,
+            String aerialway_heating, String aerialway_duration) {
+        this.name = name;
+        this.aerialway = aerialway;
+        this.aerialway_occupancy = aerialway_occupancy;
+        this.aerialway_bubble = aerialway_bubble;
+        this.aerialway_heating = aerialway_heating;
+        this.aerialway_duration = aerialway_duration;
+    }
+
+    public Tags() {
+
+    }
+}

--- a/src/main/java/de/storchp/opentracks/osmplugin/dashboardapi/ChairLiftElements.java
+++ b/src/main/java/de/storchp/opentracks/osmplugin/dashboardapi/ChairLiftElements.java
@@ -1,0 +1,87 @@
+package de.storchp.opentracks.osmplugin.dashboardapi;
+
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.util.ArrayList;
+
+public class ChairLiftElements {
+    public String type;
+    public long id;
+    public Bounds bounds;
+    public ArrayList<Object> nodes;
+    public ArrayList<Geometry> geometry;
+    public Tags tags;
+
+    public ChairLiftElements(String type, long id, Bounds bounds, ArrayList<Object> nodes,
+                       ArrayList<Geometry> geometry, Tags tags) {
+        this.type = type;
+        this.id = id;
+        this.bounds = bounds;
+        this.nodes = nodes;
+        this.geometry = geometry;
+        this.tags = tags;
+    }
+
+    public ChairLiftElements() {
+
+    }
+
+    public static ChairLiftElements parseJsonElement(JSONObject jsonObject) throws JSONException {
+        ChairLiftElements chairLiftElements = new ChairLiftElements();
+        chairLiftElements.type = jsonObject.optString("type", "");
+        chairLiftElements.id = jsonObject.optInt("id", 0);
+
+        // Parsing bounds
+        JSONObject boundsObj = jsonObject.optJSONObject("bounds");
+        if (boundsObj != null) {
+            chairLiftElements.bounds = new Bounds();
+            chairLiftElements.bounds.minlat = boundsObj.optDouble("minlat", 0.0);
+            chairLiftElements.bounds.minlon = boundsObj.optDouble("minlon", 0.0);
+            chairLiftElements.bounds.maxlat = boundsObj.optDouble("maxlat", 0.0);
+            chairLiftElements.bounds.maxlon = boundsObj.optDouble("maxlon", 0.0);
+        }
+
+        // Parsing nodes
+        JSONArray nodesArray = jsonObject.optJSONArray("nodes");
+        if (nodesArray != null) {
+            chairLiftElements.nodes = new ArrayList<>();
+            for (int i = 0; i < nodesArray.length(); i++) {
+                chairLiftElements.nodes.add(nodesArray.optLong(i, 0L));
+            }
+        }
+
+        // Parsing geometry
+        JSONArray geometryArray = jsonObject.optJSONArray("geometry");
+        if (geometryArray != null) {
+            for (int i = 0; i < geometryArray.length(); i++) {
+                JSONObject geometryObj = geometryArray.optJSONObject(i);
+                chairLiftElements.geometry = new ArrayList<>();
+                if (geometryObj != null) {
+                    Geometry geometry = new Geometry();
+                    geometry.lat = geometryObj.optDouble("lat", 0.0);
+                    geometry.lon = geometryObj.optDouble("lon", 0.0);
+                    chairLiftElements.geometry.add(geometry);
+                }
+            }
+        }
+
+        // Parsing tags
+        JSONObject tagsObj = jsonObject.optJSONObject("tags");
+        if (tagsObj != null) {
+            Tags tags = new Tags();
+            tags.name = tagsObj.optString("name", "");
+            tags.aerialway = tagsObj.optString("aerialway", "");
+            tags.aerialway_occupancy = tagsObj.optString("aerialway:occupancy", "");
+            tags.aerialway_bubble = tagsObj.optString("aerialway:bubble", "");
+            tags.aerialway_heating = tagsObj.optString("aerialway:heating", "");
+            tags.aerialway_duration = tagsObj.optString("aerialway:duration", "");
+            chairLiftElements.tags = tags;
+        }
+
+        return chairLiftElements;
+    }
+
+}
+


### PR DESCRIPTION
Issue #23 

# Added code to get trail_name from chair_lift API response object.

## Code Modifications

- The ChairLift.Java class was created to include a list that could be used to hold the elements that we received in the response from the chairlift-data API.
- ChairLiftElements was created in order to parse JSON element data into ChairLIftElement.
- In order to parse the data from the JSON element into the ChairLIftElement, a null check was included.
- Added a getter to the ChairLift.java class that will yield the trails list, comprising of the following: type, id, bounds, nodes, geometry, and tags. Anyone who wishes to obtain the name of the tag can use this function to obtain a list from which the tag's name can be obtained.

### ChairLiftElements.java
The ChairLiftElements.Java will have required parsing feature to pass json data into ChairLiftElement.
![Screenshot 2024-04-06 232720](https://github.com/RRK1000/OSMDashboard-Winter-2024-SOEN-6431/assets/84213511/c695b2f4-0701-4cd7-a706-bccb68dafc2f)

### ChairLift.java
The list of chairLift data will be saved by chairLifts list. Because this class is now singleton, the chairLifts list can be used elsewhere.
![Screenshot 2024-04-06 232235](https://github.com/RRK1000/OSMDashboard-Winter-2024-SOEN-6431/assets/84213511/0a5df623-966a-4efc-ab79-693cb8712d05)

### MapsActivity.Java
The below lines will pass the json data which will be parsed and added to the list of chairLift.
![Screenshot 2024-04-06 233038](https://github.com/RRK1000/OSMDashboard-Winter-2024-SOEN-6431/assets/84213511/96aa006d-1524-49b3-9f98-4a1ea661cb96)

