### PR TITLE
add method to expose chair lift names

### DIFF
--- a/src/main/java/de/storchp/opentracks/osmplugin/dashboardapi/ChairLift.java
+++ b/src/main/java/de/storchp/opentracks/osmplugin/dashboardapi/ChairLift.java
@@ -31,6 +31,14 @@ public class ChairLift {
     public void clearData() {
         this.chairLifts.clear();
     }
+    public List<String> getChairLiftNames() {
+        List<String> chairLiftNames = new ArrayList<>();
+        for (ChairLiftElements element : chairLifts) {
+            chairLiftNames.add(element.tags.name);
+        }
+        return chairLiftNames;
+    }
+
 
 }
 


### PR DESCRIPTION
adding the getChairLiftNames() method in the ChairLift class exposes chair lift names, and it can be used elsewhere in the application where chair lift names are required.